### PR TITLE
Disable PGP security feature

### DIFF
--- a/configs/pgp_security.json
+++ b/configs/pgp_security.json
@@ -1,5 +1,5 @@
 {
-  "enabled": true,
+  "enabled": false,
   "keyring_path": "/home/runner/work/DevUl-Army--__--Living-Sriracha-AGI/DevUl-Army--__--Living-Sriracha-AGI/.pgp_keyring",
   "signing_required": [
     "*.sh",


### PR DESCRIPTION
Changed the PGP security setting to disabled.

## Summary by Sourcery

Enhancements:
- Set PGP security setting to disabled in configs/pgp_security.json