### PR TITLE
Potential fix for code scanning alert no. 5: Code injection

### DIFF
--- a/.github/workflows/agent-command-router.yml
+++ b/.github/workflows/agent-command-router.yml
@@ -17,9 +17,10 @@ jobs:
       
       - name: Parse command
         id: cmd
+        env:
+          COMMENT_BODY: ${{ github.event.comment.body }}
         run: |
-          COMMENT_BODY="${{ github.event.comment.body }}"
-          echo "full_comment=${COMMENT_BODY}" >> $GITHUB_OUTPUT
+          echo "full_comment=$COMMENT_BODY" >> $GITHUB_OUTPUT
           
           # Extract command (first word starting with /)
           COMMAND=$(echo "$COMMENT_BODY" | grep -oE '^/[a-zA-Z-]+' | head -1)


### PR DESCRIPTION
Potential fix for [https://github.com/spiralgang/DevUl-Army--__--Living-Sriracha-AGI/security/code-scanning/5](https://github.com/spiralgang/DevUl-Army--__--Living-Sriracha-AGI/security/code-scanning/5)

To fix this CodeQL warning, you need to remove the direct use of `${{ github.event.comment.body }}` expression inside the shell script and instead use a shell environment variable. That is:
- Pass `github.event.comment.body` to the step via `env: COMMENT_BODY: ${{ github.event.comment.body }}`.
- Reference the value using shell native variable expansion: `$COMMENT_BODY` in all shell code instead of `${{ github.event.comment.body }}`.

You should also update all subsequent usage in the shell script block to ensure it uses `$COMMENT_BODY` and *not* the workflow expression syntax, and review any other direct uses (within `run:` or similar) in the workflow for similar injections.

No new package imports are required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
